### PR TITLE
Allow users to include a custom drop area message

### DIFF
--- a/src/js/ng-dropzone.js
+++ b/src/js/ng-dropzone.js
@@ -28,8 +28,9 @@
     }).directive('ngDropzone', ['$timeout', 'dropzoneOps', function($timeout, dropzoneOps){
       return {
         restrict : 'AE',
-        template : '<div></div>',
+        template : '<div ng-transclude></div>',
         replace : true,
+        transclude: true,
         scope : {
           options : '=?', //http://www.dropzonejs.com/#configuration-options
           callbacks : '=?', //http://www.dropzonejs.com/#events


### PR DESCRIPTION
I was attempting to customize the drop area's message as described here: http://www.dropzonejs.com/#tips and realized the directive was overwriting anything I'd include there. 

Adding ng-transclude and the transclude: true property brings anything a user includes inside the <ng-dropzone></ng-dropzone> tags in the template.